### PR TITLE
fix: change css class names for logo animation

### DIFF
--- a/src/app/comp/xunk-spinner/xunk-spinner.component.html
+++ b/src/app/comp/xunk-spinner/xunk-spinner.component.html
@@ -1,11 +1,11 @@
 <div class="loading-fader" *ngIf="!error">
-  <img class="p1" src="assets/petal.svg">
-  <img class="p2" src="assets/petal.svg">
-  <img class="p3" src="assets/petal.svg">
-  <img class="p4" src="assets/petal.svg">
-  <img class="p5" src="assets/petal.svg">
-  <img class="p6" src="assets/petal.svg">
-  <img class="p7" src="assets/petal.svg">
+  <img class="logo-instiapp-1" src="assets/petal.svg">
+  <img class="logo-instiapp-2" src="assets/petal.svg">
+  <img class="logo-instiapp-3" src="assets/petal.svg">
+  <img class="logo-instiapp-4" src="assets/petal.svg">
+  <img class="logo-instiapp-5" src="assets/petal.svg">
+  <img class="logo-instiapp-6" src="assets/petal.svg">
+  <img class="logo-instiapp-7" src="assets/petal.svg">
 </div>
 
 <div class="nothing-at-all" *ngIf="error">

--- a/src/index.html
+++ b/src/index.html
@@ -78,21 +78,21 @@
       animation: spinner 2s infinite ease-in-out;
     }
 
-    .p1 { transform: rotate(67deg); }
-    .p2 { transform: rotate(45deg); }
-    .p3 { transform: rotate(20deg); }
-    .p4 { transform: rotate(00deg); }
-    .p5 { transform: rotate(-20deg); }
-    .p6 { transform: rotate(-45deg); }
-    .p7 { transform: rotate(-67deg); }
+    .logo1 { transform: rotate(67deg); }
+    .logo2 { transform: rotate(45deg); }
+    .logo3 { transform: rotate(20deg); }
+    .logo4 { transform: rotate(00deg); }
+    .logo5 { transform: rotate(-20deg); }
+    .logo6 { transform: rotate(-45deg); }
+    .logo7 { transform: rotate(-67deg); }
 
-    .loading-fader .p7 { -webkit-animation-delay: 0.09s; animation-delay: 0.09s; }
-    .loading-fader .p6 { -webkit-animation-delay: 0.18s; animation-delay: 0.18s; }
-    .loading-fader .p5 { -webkit-animation-delay: 0.27s; animation-delay: 0.27s; }
-    .loading-fader .p4 { -webkit-animation-delay: 0.36s; animation-delay: 0.36s; }
-    .loading-fader .p3 { -webkit-animation-delay: 0.45s; animation-delay: 0.45s; }
-    .loading-fader .p2 { -webkit-animation-delay: 0.54s; animation-delay: 0.54s; }
-    .loading-fader .p1 { -webkit-animation-delay: 0.63s; animation-delay: 0.63s; }
+    .loading-fader .logo7 { -webkit-animation-delay: 0.09s; animation-delay: 0.09s; }
+    .loading-fader .lgoo6 { -webkit-animation-delay: 0.18s; animation-delay: 0.18s; }
+    .loading-fader .logo5 { -webkit-animation-delay: 0.27s; animation-delay: 0.27s; }
+    .loading-fader .logo4 { -webkit-animation-delay: 0.36s; animation-delay: 0.36s; }
+    .loading-fader .logo3 { -webkit-animation-delay: 0.45s; animation-delay: 0.45s; }
+    .loading-fader .logo2 { -webkit-animation-delay: 0.54s; animation-delay: 0.54s; }
+    .loading-fader .logo1 { -webkit-animation-delay: 0.63s; animation-delay: 0.63s; }
 
     @keyframes spinner {
       0% { opacity: 0.15;}
@@ -105,13 +105,13 @@
 
   <app-root>
     <div class="loading-fader">
-      <img class="p1" src="assets/petal.svg">
-      <img class="p2" src="assets/petal.svg">
-      <img class="p3" src="assets/petal.svg">
-      <img class="p4" src="assets/petal.svg">
-      <img class="p5" src="assets/petal.svg">
-      <img class="p6" src="assets/petal.svg">
-      <img class="p7" src="assets/petal.svg">
+      <img class="logo1" src="assets/petal.svg">
+      <img class="logo2" src="assets/petal.svg">
+      <img class="logo3" src="assets/petal.svg">
+      <img class="logo4" src="assets/petal.svg">
+      <img class="logo5" src="assets/petal.svg">
+      <img class="logo6" src="assets/petal.svg">
+      <img class="logo7" src="assets/petal.svg">
     </div>
   </app-root>
 

--- a/src/index.html
+++ b/src/index.html
@@ -78,21 +78,21 @@
       animation: spinner 2s infinite ease-in-out;
     }
 
-    .logo1 { transform: rotate(67deg); }
-    .logo2 { transform: rotate(45deg); }
-    .logo3 { transform: rotate(20deg); }
-    .logo4 { transform: rotate(00deg); }
-    .logo5 { transform: rotate(-20deg); }
-    .logo6 { transform: rotate(-45deg); }
-    .logo7 { transform: rotate(-67deg); }
+    .logo-instiapp-1 { transform: rotate(67deg); }
+    .logo-instiapp-2 { transform: rotate(45deg); }
+    .logo-instiapp-3 { transform: rotate(20deg); }
+    .logo-instiapp-4 { transform: rotate(00deg); }
+    .logo-instiapp-5 { transform: rotate(-20deg); }
+    .logo-instiapp-6 { transform: rotate(-45deg); }
+    .logo-instiapp-7 { transform: rotate(-67deg); }
 
-    .loading-fader .logo7 { -webkit-animation-delay: 0.09s; animation-delay: 0.09s; }
-    .loading-fader .lgoo6 { -webkit-animation-delay: 0.18s; animation-delay: 0.18s; }
-    .loading-fader .logo5 { -webkit-animation-delay: 0.27s; animation-delay: 0.27s; }
-    .loading-fader .logo4 { -webkit-animation-delay: 0.36s; animation-delay: 0.36s; }
-    .loading-fader .logo3 { -webkit-animation-delay: 0.45s; animation-delay: 0.45s; }
-    .loading-fader .logo2 { -webkit-animation-delay: 0.54s; animation-delay: 0.54s; }
-    .loading-fader .logo1 { -webkit-animation-delay: 0.63s; animation-delay: 0.63s; }
+    .loading-fader .logo-instiapp-7 { -webkit-animation-delay: 0.09s; animation-delay: 0.09s; }
+    .loading-fader .logo-instiapp-6 { -webkit-animation-delay: 0.18s; animation-delay: 0.18s; }
+    .loading-fader .logo-instiapp-5 { -webkit-animation-delay: 0.27s; animation-delay: 0.27s; }
+    .loading-fader .logo-instiapp-4 { -webkit-animation-delay: 0.36s; animation-delay: 0.36s; }
+    .loading-fader .logo-instiapp-3 { -webkit-animation-delay: 0.45s; animation-delay: 0.45s; }
+    .loading-fader .logo-instiapp-2 { -webkit-animation-delay: 0.54s; animation-delay: 0.54s; }
+    .loading-fader .logo-instiapp-1 { -webkit-animation-delay: 0.63s; animation-delay: 0.63s; }
 
     @keyframes spinner {
       0% { opacity: 0.15;}
@@ -105,13 +105,13 @@
 
   <app-root>
     <div class="loading-fader">
-      <img class="logo1" src="assets/petal.svg">
-      <img class="logo2" src="assets/petal.svg">
-      <img class="logo3" src="assets/petal.svg">
-      <img class="logo4" src="assets/petal.svg">
-      <img class="logo5" src="assets/petal.svg">
-      <img class="logo6" src="assets/petal.svg">
-      <img class="logo7" src="assets/petal.svg">
+      <img class="logo-instiapp-1" src="assets/petal.svg">
+      <img class="logo-instiapp-2" src="assets/petal.svg">
+      <img class="logo-instiapp-3" src="assets/petal.svg">
+      <img class="logo-instiapp-4" src="assets/petal.svg">
+      <img class="logo-instiapp-5" src="assets/petal.svg">
+      <img class="logo-instiapp-6" src="assets/petal.svg">
+      <img class="logo-instiapp-7" src="assets/petal.svg">
     </div>
   </app-root>
 


### PR DESCRIPTION
`p` is very common css class, and causing some problems (placement blog entries)
Current fix: change p<num> to logo<num>